### PR TITLE
Deprecated pypi package removed

### DIFF
--- a/src/requirements-root.txt
+++ b/src/requirements-root.txt
@@ -21,7 +21,6 @@ MarkupSafe
 numpy
 openapi-codec
 pandas
-psycopg2
 psycopg2-binary
 python-dateutil
 pytz

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -31,7 +31,6 @@ mccabe==0.6.1
 numpy==1.15.4
 openapi-codec==1.3.2
 pandas==0.23.4
-psycopg2==2.7.6.1
 psycopg2-binary==2.7.6.1
 pycodestyle==2.4.0
 pyflakes==2.0.0


### PR DESCRIPTION
Removes warning that suggest moving to psycopg2-binary (which is already performed).