### PR TITLE
Afval acc prd

### DIFF
--- a/src/datasets/afvalwegingen/import/import.sh
+++ b/src/datasets/afvalwegingen/import/import.sh
@@ -7,6 +7,7 @@ export SHARED_DIR=${SCRIPT_DIR}/../../shared
 source ${SHARED_DIR}/import/config.sh
 source ${SHARED_DIR}/import/before.sh
 
+ENVIRONMENT=${DATAPUNT_ENVIRONMENT:-acceptance}
 
 echo "Drop and create schema"
 
@@ -21,7 +22,7 @@ echo "Download and import pgsql dumps"
 
 for ds_filename in afval_weging afval_container afval_cluster
 do
-    ZIP_FILE=$ds_filename.zip
+    ZIP_FILE=$ENVIRONMENT/$ds_filename.zip
     OBJECTSTORE_PATH=afval/$ZIP_FILE
 
     echo "Download file from objectstore and unzipping"

--- a/src/datasets/afvalwegingen/import/import.sh
+++ b/src/datasets/afvalwegingen/import/import.sh
@@ -9,13 +9,6 @@ source ${SHARED_DIR}/import/before.sh
 
 ENVIRONMENT=${DATAPUNT_ENVIRONMENT:-acceptance}
 
-# Temporary workaround, to use old location (root) for prod
-if [ $ENVIRONMENT = "production" ]
-then
-    export ENVIRONMENT=""
-fi
-
-
 echo "Drop and create schema"
 
 psql -X --set ON_ERROR_STOP=on <<SQL
@@ -29,7 +22,13 @@ echo "Download and import pgsql dumps"
 
 for ds_filename in afval_weging afval_container afval_cluster
 do
-    ZIP_FILE=$ENVIRONMENT/$ds_filename.zip
+    # Temporary workaround, to use old location (root) for prod
+    if [ $ENVIRONMENT = "production" ]
+    then
+        ZIP_FILE=$ds_filename.zip
+    else
+        ZIP_FILE=$ENVIRONMENT/$ds_filename.zip
+    fi
     OBJECTSTORE_PATH=afval/$ZIP_FILE
 
     echo "Download file from objectstore and unzipping"

--- a/src/datasets/afvalwegingen/import/import.sh
+++ b/src/datasets/afvalwegingen/import/import.sh
@@ -9,6 +9,13 @@ source ${SHARED_DIR}/import/before.sh
 
 ENVIRONMENT=${DATAPUNT_ENVIRONMENT:-acceptance}
 
+# Temporary workaround, to use old location (root) for prod
+if [ $ENVIRONMENT = "production" ]
+then
+    export ENVIRONMENT=""
+fi
+
+
 echo "Drop and create schema"
 
 psql -X --set ON_ERROR_STOP=on <<SQL

--- a/src/datasets/bb_quotum/import/import.sh
+++ b/src/datasets/bb_quotum/import/import.sh
@@ -9,6 +9,12 @@ source ${SHARED_DIR}/import/before.sh
 
 ENVIRONMENT=${DATAPUNT_ENVIRONMENT:-acceptance}
 
+# Temporary workaround, to use old location (root) for prod
+if [ $ENVIRONMENT = "production" ]
+then
+    export ENVIRONMENT=""
+fi
+
 
 DS_FILENAME=bb_quotum.sql
 OBJECTSTORE_PATH=bed_and_breakfast/${ENVIRONMENT}/${DS_FILENAME}

--- a/src/datasets/bb_quotum/import/import.sh
+++ b/src/datasets/bb_quotum/import/import.sh
@@ -9,13 +9,6 @@ source ${SHARED_DIR}/import/before.sh
 
 ENVIRONMENT=${DATAPUNT_ENVIRONMENT:-acceptance}
 
-# Temporary workaround, to use old location (root) for prod
-if [ $ENVIRONMENT = "production" ]
-then
-    export ENVIRONMENT=""
-fi
-
-
 DS_FILENAME=bb_quotum.sql
 OBJECTSTORE_PATH=bed_and_breakfast/${ENVIRONMENT}/${DS_FILENAME}
 


### PR DESCRIPTION
Aanpassingen om bij de afval dataset ook onderscheid tussen acc en prod te maken.

Tijdelijk wordt voor prod nog even de 'root' van de datastore gebruikt, door ENVIRONMENT aan ta passen. Dit moet later weer verwijderd worden. 