### PR TITLE
Add Date filtering to GenericFilters.

### DIFF
--- a/src/test/test_gen_api.py
+++ b/src/test/test_gen_api.py
@@ -30,7 +30,8 @@ naam character varying(128),
 prijs integer,
 sterren integer,
 smaken character varying(256),
-wkb_geometry geometry(Geometry,28992)
+wkb_geometry geometry(Geometry,28992),
+datum date
             )'''
 
         add_constraint = '''
@@ -42,10 +43,10 @@ CREATE INDEX icp_data_wkb_geometry_geom_idx
 ON icp_data USING gist(wkb_geometry);
         '''
         insert_data = '''
-INSERT INTO icp_data (icp_id, naam, prijs, sterren, smaken, wkb_geometry) VALUES
-(1, 'IJscuypje', 3, 4, 'pistache', ST_Transform(ST_GeomFromText('POINT(4.911880 52.367379)', 4326), 28992) ),
-(2, 'De ijsfiets', 2, 3, 'sinaasappel', ST_Transform(ST_GeomFromText('POINT(4.906130 52.365912)', 4326), 28992) ),
-(3, 'Het ijsboefje', 1, 4, 'straciatelli', ST_Transform(ST_GeomFromText('POINT(4.918146 52.358312)', 4326), 28992) );
+INSERT INTO icp_data (icp_id, naam, prijs, sterren, smaken, wkb_geometry, datum) VALUES
+(1, 'IJscuypje', 3, 4, 'pistache', ST_Transform(ST_GeomFromText('POINT(4.911880 52.367379)', 4326), 28992), null ),
+(2, 'De ijsfiets', 2, 3, 'sinaasappel', ST_Transform(ST_GeomFromText('POINT(4.906130 52.365912)', 4326), 28992), '2020-01-01'),
+(3, 'Het ijsboefje', 1, 4, 'straciatelli', ST_Transform(ST_GeomFromText('POINT(4.918146 52.358312)', 4326), 28992),  '2020-02-01');
         '''
         with connection.cursor() as cursor:
             cursor.execute(create_table)
@@ -118,3 +119,31 @@ INSERT INTO icp_data (icp_id, naam, prijs, sterren, smaken, wkb_geometry) VALUES
     def test_not_exist2(self):
         response = self.http_client.get('/vsd/ijs/100/')
         assert response.status_code == 404
+
+    def test_date_field_exact_match(self):
+        response = self.http_client.get('/vsd/ijs/?datum=2020-01-01')
+        assert response.status_code == 200
+        result = json.loads(response.content)
+        assert len(result['results']) == 1
+        assert result['results'][0]['naam'] == 'De ijsfiets'
+
+    def test_date_field_lte(self):
+        response = self.http_client.get('/vsd/ijs/?datum__lte=2020-01-02')
+        assert response.status_code == 200
+        result = json.loads(response.content)
+        assert len(result['results']) == 1
+        assert result['results'][0]['naam'] == 'De ijsfiets'
+
+    def test_date_field_gte(self):
+        response = self.http_client.get('/vsd/ijs/?datum__gte=2020-01-01')
+        assert response.status_code == 200
+        result = json.loads(response.content)
+        assert len(result['results']) == 2
+        assert result['results'][0]['naam'] == 'De ijsfiets'
+        assert result['results'][1]['naam'] == 'Het ijsboefje'
+
+    def test_date_field_incorrect_date_results_in_error(self):
+        response = self.http_client.get('/vsd/ijs/?datum__gte=vandaag')
+        assert response.status_code == 400
+        result = json.loads(response.content)
+        assert result == {'datum__gte': ['Enter a valid date.']}

--- a/src/test/test_gen_api.py
+++ b/src/test/test_gen_api.py
@@ -146,4 +146,4 @@ INSERT INTO icp_data (icp_id, naam, prijs, sterren, smaken, wkb_geometry, datum)
         response = self.http_client.get('/vsd/ijs/?datum__gte=vandaag')
         assert response.status_code == 400
         result = json.loads(response.content)
-        assert result == {'datum__gte': ['Enter a valid date.']}
+        assert result == {'datum__gte': ['Enter a valid date/time.']}

--- a/src/various_small_datasets/gen_api/views.py
+++ b/src/various_small_datasets/gen_api/views.py
@@ -174,10 +174,10 @@ def filter_factory(ds_name, model):
     date_filters = dict()
     for field in model._meta.fields:
         if isinstance(field, models.DateField):
-            date_filters[field.name] = filters.DateFilter()
-            date_filters[f'{field.name}__lte'] = filters.DateFilter(
+            date_filters[field.name] = filters.DateTimeFilter()
+            date_filters[f'{field.name}__lte'] = filters.DateTimeFilter(
                 field_name=field.name, method='date__lte')
-            date_filters[f'{field.name}__gte'] = filters.DateFilter(
+            date_filters[f'{field.name}__gte'] = filters.DateTimeFilter(
                 field_name=field.name, method='date__gte')
 
     fields += date_filters.keys()

--- a/src/various_small_datasets/gen_api/views.py
+++ b/src/various_small_datasets/gen_api/views.py
@@ -3,6 +3,7 @@ import time
 
 from datapunt_api.rest import DatapuntViewSet
 from django.urls import reverse
+from django.db import models
 from rest_framework.response import Response
 from rest_framework.exceptions import NotFound, ParseError
 
@@ -149,6 +150,14 @@ class GenericFilter(FilterSet):
     def format_filter(queryset, _filter_name, value):
         return queryset
 
+    @staticmethod
+    def date__lte(queryset, field_name, value):
+        return queryset.filter(**{f'{field_name}__lte': value})
+
+    @staticmethod
+    def date__gte(queryset, field_name, value):
+        return queryset.filter(**{f'{field_name}__gte': value})
+
 
 def filter_factory(ds_name, model):
     model_name = ds_name.upper() + 'GenericFilter'
@@ -161,6 +170,18 @@ def filter_factory(ds_name, model):
     location = filters.CharFilter(field_name=location_filter_name, method="location_filter")
     name = filters.CharFilter(field_name=name_field, method="name_filter")
 
+    # Create datetime filters
+    date_filters = dict()
+    for field in model._meta.fields:
+        if isinstance(field, models.DateField):
+            date_filters[field.name] = filters.DateFilter()
+            date_filters[f'{field.name}__lte'] = filters.DateFilter(
+                field_name=field.name, method='date__lte')
+            date_filters[f'{field.name}__gte'] = filters.DateFilter(
+                field_name=field.name, method='date__gte')
+
+    fields += date_filters.keys()
+
     new_meta_attrs = {'model': model,
                       'fields': fields,
                       }
@@ -170,6 +191,7 @@ def filter_factory(ds_name, model):
         'Meta': new_meta,
         geometry_field: location,
         name_field: name,
+        **date_filters
     }
     return type(model_name, (GenericFilter,), new_attrs)
 


### PR DESCRIPTION
Date filters to Generic filters.

Adding 3 new filters:

- `{field_name}` = Exact match
- `{field_name}__lte` = Lower then or equal to date
- `{field_name}__gte` = Greater then or equal to date

New filters will be added to all DateFields in dataset.