### PR TITLE
For afval now use $ENVIRONMENT location for production.

### DIFF
--- a/src/datasets/afvalwegingen/import/import.sh
+++ b/src/datasets/afvalwegingen/import/import.sh
@@ -22,13 +22,7 @@ echo "Download and import pgsql dumps"
 
 for ds_filename in afval_weging afval_container afval_cluster
 do
-    # Temporary workaround, to use old location (root) for prod
-    if [ $ENVIRONMENT = "production" ]
-    then
-        ZIP_FILE=$ds_filename.zip
-    else
-        ZIP_FILE=$ENVIRONMENT/$ds_filename.zip
-    fi
+    ZIP_FILE=$ENVIRONMENT/$ds_filename.zip
     OBJECTSTORE_PATH=afval/$ZIP_FILE
 
     echo "Download file from objectstore and unzipping"


### PR DESCRIPTION
Er werd tijdelijk voor PROD nog naar de oude locatie op de objectstore gekeken. Dat hoeft nu niet meer.