### PR TITLE
Bump Django to 2.2.28

### DIFF
--- a/src/requirements.in
+++ b/src/requirements.in
@@ -1,5 +1,5 @@
 datapunt-objectstore == 2019.4.8
-Django == 2.2.13
+Django == 2.2.28
 django-choices == 1.7.1
 django-cors-headers == 3.2.1
 django-filter == 2.2.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,95 +4,287 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-appdirs==1.4.3            # via zeep
-attrs==19.3.0             # via jsonschema, pytest, zeep
-babel==2.8.0              # via oslo.i18n
-cached-property==1.5.1    # via zeep
-certifi==2019.11.28       # via requests, sentry-sdk
-chardet==3.0.4            # via requests
-click==7.0                # via geomet, mappyfile
-coreapi==2.3.3            # via django-rest-swagger, openapi-codec
-coreschema==0.0.4         # via coreapi
-coverage==5.0.3           # via pytest-cov
-datapunt-config-loader==1.1.2  # via datapunt-objectstore
-datapunt-objectstore==2019.4.8  # via -r requirements.in
-debtcollector==1.22.0     # via oslo.config, oslo.utils, python-keystoneclient
-defusedxml==0.6.0         # via djangorestframework-xml, zeep
-django-choices==1.7.1     # via -r requirements.in
-django-cors-headers==3.2.1  # via -r requirements.in
-django-filter==2.2.0      # via -r requirements.in
-django-rest-swagger==2.2.0  # via -r requirements.in
-django==2.2.13            # via -r requirements.in, django-choices, django-cors-headers, django-filter, djangorestframework
-djangorestframework-csv==2.1.0  # via drf-amsterdam
-djangorestframework-gis==0.15  # via -r requirements.in
-djangorestframework-xml==1.4.0  # via drf-amsterdam
-djangorestframework==3.11.0  # via -r requirements.in, django-rest-swagger, djangorestframework-csv, djangorestframework-gis, drf-amsterdam, drf-extensions
-drf-amsterdam==0.3.2      # via -r requirements.in
-drf-extensions==0.5.0     # via drf-amsterdam
-entrypoints==0.3          # via flake8
-flake8==3.7.9             # via -r requirements.in
-geojson==2.5.0            # via -r requirements.in
-geomet==0.2.1.post1       # via -r requirements.in
-idna==2.8                 # via requests
-iso8601==0.1.12           # via keystoneauth1, oslo.utils
-isodate==0.6.0            # via zeep
-itypes==1.1.0             # via coreapi
-jinja2==2.10.3            # via -r requirements.in, coreschema
-jsonref==0.2              # via mappyfile
-jsonschema==3.2.0         # via datapunt-config-loader, mappyfile
-keystoneauth1==3.18.0     # via python-keystoneclient
-lark-parser==0.7.8        # via mappyfile
-lxml==4.4.2               # via zeep
-mappyfile==0.8.4          # via -r requirements.in
-markupsafe==1.1.1         # via jinja2
-mccabe==0.6.1             # via flake8
-more-itertools==8.1.0     # via pytest
-msgpack==0.6.2            # via oslo.serialization
-netaddr==0.7.19           # via oslo.config, oslo.utils
-netifaces==0.10.9         # via oslo.utils
-numpy==1.18.1             # via -r requirements.in, pandas
-openapi-codec==1.3.2      # via django-rest-swagger
-os-service-types==1.7.0   # via keystoneauth1
-oslo.config==7.0.0        # via python-keystoneclient
-oslo.i18n==3.25.1         # via oslo.config, oslo.utils, python-keystoneclient
-oslo.serialization==2.29.2  # via python-keystoneclient
-oslo.utils==3.42.1        # via oslo.serialization, python-keystoneclient
-packaging==20.0           # via pytest, pytest-sugar
-pandas==0.25.3            # via -r requirements.in
-pbr==5.4.4                # via debtcollector, keystoneauth1, os-service-types, oslo.i18n, oslo.serialization, oslo.utils, python-keystoneclient, stevedore
-pluggy==0.13.1            # via pytest
-psycopg2-binary==2.8.4    # via -r requirements.in
-py==1.8.1                 # via pytest
-pycodestyle==2.5.0        # via flake8
-pyflakes==2.1.1           # via flake8
-pylru==1.2.0              # via -r requirements.in
-pyparsing==2.4.6          # via oslo.utils, packaging
-pyrsistent==0.15.7        # via jsonschema
-pytest-cov==2.8.1         # via -r requirements.in
-pytest-django==3.7.0      # via -r requirements.in
-pytest-sugar==0.9.2       # via -r requirements.in
-pytest==5.3.2             # via -r requirements.in, pytest-cov, pytest-django, pytest-sugar
-python-dateutil==2.8.1    # via -r requirements.in, pandas
-python-keystoneclient==3.22.0  # via datapunt-objectstore
-python-swiftclient==3.8.1  # via datapunt-objectstore
-pytz==2019.3              # via -r requirements.in, babel, django, oslo.serialization, oslo.utils, pandas, zeep
-pyyaml==5.3               # via datapunt-config-loader, oslo.config, oslo.serialization
-requests-toolbelt==0.9.1  # via -r requirements.in, zeep
-requests==2.22.0          # via -r requirements.in, coreapi, keystoneauth1, oslo.config, python-keystoneclient, python-swiftclient, requests-toolbelt, zeep
-rfc3986==1.3.2            # via oslo.config
-sentry-sdk==0.14.0        # via -r requirements.in
-simplejson==3.17.0        # via -r requirements.in, django-rest-swagger
-six==1.14.0               # via debtcollector, django-choices, djangorestframework-csv, geomet, isodate, jsonschema, keystoneauth1, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, packaging, pyrsistent, python-dateutil, python-keystoneclient, python-swiftclient, stevedore, zeep
-sqlparse==0.3.0           # via django
-stevedore==1.31.0         # via keystoneauth1, oslo.config, python-keystoneclient
-termcolor==1.1.0          # via pytest-sugar
-unicodecsv==0.14.1        # via djangorestframework-csv
-uritemplate==3.0.1        # via coreapi
-urllib3==1.25.7           # via requests, sentry-sdk
-wcwidth==0.1.8            # via pytest
-wrapt==1.11.2             # via debtcollector
-xlrd==1.2.0               # via -r requirements.in
-zeep==3.4.0               # via -r requirements.in
+appdirs==1.4.3
+    # via zeep
+attrs==19.3.0
+    # via
+    #   jsonschema
+    #   pytest
+    #   zeep
+babel==2.8.0
+    # via oslo.i18n
+cached-property==1.5.1
+    # via zeep
+certifi==2019.11.28
+    # via
+    #   requests
+    #   sentry-sdk
+chardet==3.0.4
+    # via requests
+click==7.0
+    # via
+    #   geomet
+    #   mappyfile
+coreapi==2.3.3
+    # via
+    #   django-rest-swagger
+    #   openapi-codec
+coreschema==0.0.4
+    # via coreapi
+coverage==5.0.3
+    # via pytest-cov
+datapunt-config-loader==1.1.2
+    # via datapunt-objectstore
+datapunt-objectstore==2019.4.8
+    # via -r requirements.in
+debtcollector==1.22.0
+    # via
+    #   oslo.config
+    #   oslo.utils
+    #   python-keystoneclient
+defusedxml==0.6.0
+    # via
+    #   djangorestframework-xml
+    #   zeep
+django-choices==1.7.1
+    # via -r requirements.in
+django-cors-headers==3.2.1
+    # via -r requirements.in
+django-filter==2.2.0
+    # via -r requirements.in
+django-rest-swagger==2.2.0
+    # via -r requirements.in
+django==2.2.28
+    # via
+    #   -r requirements.in
+    #   django-choices
+    #   django-cors-headers
+    #   django-filter
+    #   djangorestframework
+djangorestframework-csv==2.1.0
+    # via drf-amsterdam
+djangorestframework-gis==0.15
+    # via -r requirements.in
+djangorestframework-xml==1.4.0
+    # via drf-amsterdam
+djangorestframework==3.11.0
+    # via
+    #   -r requirements.in
+    #   django-rest-swagger
+    #   djangorestframework-csv
+    #   djangorestframework-gis
+    #   drf-amsterdam
+    #   drf-extensions
+drf-amsterdam==0.3.2
+    # via -r requirements.in
+drf-extensions==0.5.0
+    # via drf-amsterdam
+entrypoints==0.3
+    # via flake8
+flake8==3.7.9
+    # via -r requirements.in
+geojson==2.5.0
+    # via -r requirements.in
+geomet==0.2.1.post1
+    # via -r requirements.in
+idna==2.8
+    # via requests
+iso8601==0.1.12
+    # via
+    #   keystoneauth1
+    #   oslo.utils
+isodate==0.6.0
+    # via zeep
+itypes==1.1.0
+    # via coreapi
+jinja2==2.10.3
+    # via
+    #   -r requirements.in
+    #   coreschema
+jsonref==0.2
+    # via mappyfile
+jsonschema==3.2.0
+    # via
+    #   datapunt-config-loader
+    #   mappyfile
+keystoneauth1==3.18.0
+    # via python-keystoneclient
+lark-parser==0.7.8
+    # via mappyfile
+lxml==4.4.2
+    # via zeep
+mappyfile==0.8.4
+    # via -r requirements.in
+markupsafe==1.1.1
+    # via jinja2
+mccabe==0.6.1
+    # via flake8
+more-itertools==8.1.0
+    # via pytest
+msgpack==0.6.2
+    # via oslo.serialization
+netaddr==0.7.19
+    # via
+    #   oslo.config
+    #   oslo.utils
+netifaces==0.10.9
+    # via oslo.utils
+numpy==1.18.1
+    # via
+    #   -r requirements.in
+    #   pandas
+openapi-codec==1.3.2
+    # via django-rest-swagger
+os-service-types==1.7.0
+    # via keystoneauth1
+oslo.config==7.0.0
+    # via python-keystoneclient
+oslo.i18n==3.25.1
+    # via
+    #   oslo.config
+    #   oslo.utils
+    #   python-keystoneclient
+oslo.serialization==2.29.2
+    # via python-keystoneclient
+oslo.utils==3.42.1
+    # via
+    #   oslo.serialization
+    #   python-keystoneclient
+packaging==20.0
+    # via
+    #   pytest
+    #   pytest-sugar
+pandas==0.25.3
+    # via -r requirements.in
+pbr==5.4.4
+    # via
+    #   debtcollector
+    #   keystoneauth1
+    #   os-service-types
+    #   oslo.i18n
+    #   oslo.serialization
+    #   oslo.utils
+    #   python-keystoneclient
+    #   stevedore
+pluggy==0.13.1
+    # via pytest
+psycopg2-binary==2.8.4
+    # via -r requirements.in
+py==1.8.1
+    # via pytest
+pycodestyle==2.5.0
+    # via flake8
+pyflakes==2.1.1
+    # via flake8
+pylru==1.2.0
+    # via -r requirements.in
+pyparsing==2.4.6
+    # via
+    #   oslo.utils
+    #   packaging
+pyrsistent==0.15.7
+    # via jsonschema
+pytest-cov==2.8.1
+    # via -r requirements.in
+pytest-django==3.7.0
+    # via -r requirements.in
+pytest-sugar==0.9.2
+    # via -r requirements.in
+pytest==5.3.2
+    # via
+    #   -r requirements.in
+    #   pytest-cov
+    #   pytest-django
+    #   pytest-sugar
+python-dateutil==2.8.1
+    # via
+    #   -r requirements.in
+    #   pandas
+python-keystoneclient==3.22.0
+    # via datapunt-objectstore
+python-swiftclient==3.8.1
+    # via datapunt-objectstore
+pytz==2019.3
+    # via
+    #   -r requirements.in
+    #   babel
+    #   django
+    #   oslo.serialization
+    #   oslo.utils
+    #   pandas
+    #   zeep
+pyyaml==5.3
+    # via
+    #   datapunt-config-loader
+    #   oslo.config
+    #   oslo.serialization
+requests-toolbelt==0.9.1
+    # via
+    #   -r requirements.in
+    #   zeep
+requests==2.22.0
+    # via
+    #   -r requirements.in
+    #   coreapi
+    #   keystoneauth1
+    #   oslo.config
+    #   python-keystoneclient
+    #   python-swiftclient
+    #   requests-toolbelt
+    #   zeep
+rfc3986==1.3.2
+    # via oslo.config
+sentry-sdk==0.14.0
+    # via -r requirements.in
+simplejson==3.17.0
+    # via
+    #   -r requirements.in
+    #   django-rest-swagger
+six==1.14.0
+    # via
+    #   debtcollector
+    #   django-choices
+    #   djangorestframework-csv
+    #   geomet
+    #   isodate
+    #   jsonschema
+    #   keystoneauth1
+    #   oslo.config
+    #   oslo.i18n
+    #   oslo.serialization
+    #   oslo.utils
+    #   packaging
+    #   pyrsistent
+    #   python-dateutil
+    #   python-keystoneclient
+    #   python-swiftclient
+    #   stevedore
+    #   zeep
+sqlparse==0.3.0
+    # via django
+stevedore==1.31.0
+    # via
+    #   keystoneauth1
+    #   oslo.config
+    #   python-keystoneclient
+termcolor==1.1.0
+    # via pytest-sugar
+unicodecsv==0.14.1
+    # via djangorestframework-csv
+uritemplate==3.0.1
+    # via coreapi
+urllib3==1.25.7
+    # via
+    #   requests
+    #   sentry-sdk
+wcwidth==0.1.8
+    # via pytest
+wrapt==1.11.2
+    # via debtcollector
+xlrd==1.2.0
+    # via -r requirements.in
+zeep==3.4.0
+    # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Bump Django because of CVE-2022-28346.
https://docs.djangoproject.com/en/4.0/releases/2.2.28/